### PR TITLE
Update core/set-submitting to check whether the input state is seqabl…

### DIFF
--- a/src/fork/core.cljs
+++ b/src/fork/core.cljs
@@ -20,7 +20,10 @@
 
 (defn set-submitting
   [db path bool]
-  (assoc-in db [path :submitting?] bool))
+  (if (seqable? db)
+    (assoc-in db [path :submitting?] bool)
+    (swap! db #(assoc-in % [path :submitting?] bool))
+    ))
 
 (defn set-waiting
   [db path input-name bool]

--- a/src/fork/core.cljs
+++ b/src/fork/core.cljs
@@ -20,7 +20,7 @@
 
 (defn set-submitting
   [db path bool]
-  (if (seqable? db)
+  (if (associative? db)
     (assoc-in db [path :submitting?] bool)
     (swap! db #(assoc-in % [path :submitting?] bool))
     ))


### PR DESCRIPTION
…e or not before updating the state.

I've checked, and apparently `r/atom` is not seqable. What I'm not sure about is whether reframe's `db` is seqable, as I've never used that library.

#10 