### PR TITLE
Correctly update `:dirty` for values that are collections

### DIFF
--- a/src/fork/core.cljs
+++ b/src/fork/core.cljs
@@ -220,7 +220,8 @@
 
 (defn dirty
   [values initial-values]
-  (first (data/diff values (or initial-values {}))))
+  (let [[only-in-values only-in-initial-values _both] (data/diff values (or initial-values {}))]
+    (merge only-in-initial-values only-in-values)))
 
 (defn handle-submit
   [evt {:keys [state server on-submit prevent-default?


### PR DESCRIPTION
`(clojure.data/diff values initial-values` returns a tuple `[only-in-values, only-in-initial-values, in-both]`. If one value of the map `values` has a collection (set or vector for example), and the user removes a value in this collection, the `diff` call will show `nil` as the first tuple element.

By merging both the first and second element of the `diff` result `dirty` will still work as before for simple (non-collection) values and also for collection values.
