### PR TITLE
Fix the on-success and on-failure handler parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ You probably want to know more than the same old *Hello World* demonstration. He
 
 (rf/reg-event-fx
  :success
- (fn [{db :db} [_ result path]]
+ (fn [{db :db} [_ path result]]
    {:db (-> db
             (assoc :result result)
             (fork/set-submitting path false)
@@ -220,7 +220,7 @@ You probably want to know more than the same old *Hello World* demonstration. He
 
 (rf/reg-event-fx
  :failure
- (fn [{db :db} [_ result path]]
+ (fn [{db :db} [_ path result]]
    {:db (-> db
             (fork/set-submitting path false)
             (fork/set-server-message path "Registration failed!"))}))


### PR DESCRIPTION
The `:on-success` and `:on-failure` functions are passed the result of the request as the last argument, see https://github.com/Day8/re-frame-http-fx?tab=readme-ov-file#step-3a-handling-on-success. So we need to change the order of the parameters for the example to really work